### PR TITLE
Fix problem with network indicator being accessed from a background thread

### DIFF
--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -132,10 +132,14 @@ public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     private var requestCounter = 0 {
-        didSet {
-            let application = UIApplication.shared
-            application.isNetworkActivityIndicatorVisible = self.requestCounter > 0
-        }
+		didSet {
+			let isVisible = self.requestCounter > 0
+			
+			DispatchQueue.main.async {
+				// this must run on the main thread because it affects UI and all UI must run on the main thread
+				UIApplication.shared.isNetworkActivityIndicatorVisible = isVisible
+			}
+		}
     }
     
 }


### PR DESCRIPTION
The network indicator involves changing UI state which must be done on the main thread. This PR ensures that changes to the network indicator are performed on the main thread.